### PR TITLE
修改boss_batch_push\src\oop-self-req-main.js，解决未加载到本地配置的问题

### DIFF
--- a/src/oop-self-req-main.js
+++ b/src/oop-self-req-main.js
@@ -8,7 +8,7 @@
 // @run-at       document-start
 // @match        https://www.zhipin.com/*
 // @connect      www.tl.beer
-// @include      https://www.zhipin.com
+
 // @require      https://unpkg.com/maple-lib@1.0.3/log.js
 // @require      https://cdn.jsdelivr.net/npm/axios@1.1.2/dist/axios.min.js
 // @require      https://cdn.jsdelivr.net/npm/js2wordcloud@1.1.12/dist/js2wordcloud.min.js


### PR DESCRIPTION
去掉了boss_batch_push\src\oop-self-req-main.js中的include一行代码，解决未加载到本地配置的问题
备注：[未加载到本地配置的问题详情](https://github.com/yangfeng20/boss_batch_push/issues/49)